### PR TITLE
Initial Module Commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # aws-terraform-maintenance_window
+
+This repository contains several terraform submodules that can be used to deploy a maintenance window with targets and maintenance window tasks. This repo was divided up into two submodules to allow the user to assign multiple maintenance window tasks to a single maintenance window and single set of targets.
+
+## Module Listing
+- [window_and_targets](./modules/window_and_targets/) - A terraform module that can create a maintance window and maintenance window target.
+- [task](./modules/task) - A terraform module that can deploy a `RUN_COMMAND` maintenance window task. NOTE: Terraform currently only supports running Command documents for maintenance window tasks. Lambdas, Step Functions and SSM Automation in maintenance window tasks are currently not supported by Terraform at the time of this writing.

--- a/modules/task/README.md
+++ b/modules/task/README.md
@@ -1,0 +1,49 @@
+## Basic Usage
+```
+module "maintenance_window_task_1" {
+  source           = "git@github.com:rackspace-infrastructure-automation/aws-terraform-maintenance_window//modules/task?ref=v0.0.1"
+  max_errors       = "1"
+  service_role_arn = "arn:aws:iam::794790922771:role/aws-service-role/ssm.amazonaws.com/AWSServiceRoleForAmazonSSM"
+  priority         = "0"
+  task_type        = "RUN_COMMAND"
+  task_arn         = "arn:aws:ssm:${data.aws_region.current_region.name}:507897595701:document/Rack-ConfigureAWSTimeSync"
+  window_id        = "${module.maint_window_target.maintenance_window_id}"
+  max_concurrency  = "5"
+  target_key       = "WindowTargetIds"
+  target_values    = ["${module.maint_window_target.maintenance_window_target_id}"]
+
+  task_parameters = {
+    name   = "PreferredTimeClient"
+    values = ["chrony"]
+  }
+
+  enable_s3_logging = true
+  s3_bucket_name    = "${module.s3_logging.bucket_id}"
+  s3_region         = "${module.s3_logging.bucket_region}"
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| enable_s3_logging | Enable logging to s3 for the maintenance window task. true or false | string | `false` | no |
+| max_concurrency | The maximum number of targets that you can run this task for, in parallel. | string | `5` | no |
+| max_errors | The maximum number of errors allowed before this task stops being scheduled. Minimum length of 1. Maximum length of 7 | string | `1` | no |
+| priority | The priority of the task in the Maintenance Window. The lower the number, the higher the priority. Tasks that have the same priority are scheduled in parallel. | string | `0` | no |
+| s3_bucket_name | Name of S3 Bucket | string | `` | no |
+| s3_bucket_prefix | S3 Bucket prefix. | string | `` | no |
+| s3_region | Region S3 Bucket is in. | string | `` | no |
+| service_role_arn | The ARN of the role that's used when the task is executed. | string | `` | no |
+| target_key | The Maintenance Window Target ID from the maintenance window target template or InstanceIds | string | `` | no |
+| target_values | Comma delimited list of Physical Maintenance Window Target IDs or Instance IDs. | list | `<list>` | no |
+| task_arn | The ARN or Document resource that the task uses during execution. https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtask.html#cfn-ssm-maintenancewindowtask-taskarn | string | - | yes |
+| task_parameters | The parameters to pass to the task when it's executed. | list | `<list>` | no |
+| task_type | The type of task. Only RUN_COMMAND is supported by terraform at this point | string | `RUN_COMMAND` | no |
+| window_id | The ID of the Maintenance Window where the task is registered. Format mw-xxxxxxxxxxxx | string | `` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| maintenance_window_task_id |  |

--- a/modules/task/examples/main.tf
+++ b/modules/task/examples/main.tf
@@ -1,0 +1,70 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "random_string" "r_string" {
+  length  = 6
+  upper   = true
+  lower   = false
+  special = false
+  number  = false
+}
+
+module "vpc" {
+  source   = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.6"
+  vpc_name = "MAINT-WINDOW-TEST-${random_string.r_string.result}"
+}
+
+data "aws_region" "current_region" {}
+
+data "aws_ami" "amazon_centos_7" {
+  most_recent = true
+  owners      = ["679593333241"]
+
+  filter {
+    name   = "name"
+    values = ["CentOS Linux 7 x86_64 HVM EBS*"]
+  }
+}
+
+module "ar_test" {
+  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery.git?ref=v0.0.5"
+  ec2_os              = "centos7"
+  instance_count      = "1"
+  subnets             = ["${element(module.vpc.private_subnets, 0)}"]
+  security_group_list = ["${module.vpc.default_sg}"]
+  image_id            = "${data.aws_ami.amazon_centos_7.image_id}"
+  instance_type       = "t2.micro"
+  resource_name       = "MAINT_WINDOW_TEST-${random_string.r_string.result}"
+}
+
+module "s3_logging" {
+  source            = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.0.3"
+  bucket_name       = "s3logging-${lower(random_string.r_string.result)}"
+  bucket_acl        = "private"
+  bucket_logging    = false
+  environment       = "Development"
+  lifecycle_enabled = false
+  versioning        = false
+}
+
+module "maint_window_target" {
+  source                     = "git@github.com:rackspace-infrastructure-automation/aws-terraform-maintenance_window//modules/window_and_targets?ref=v0.0.1"
+  cutoff                     = "0"
+  duration                   = "1"
+  name                       = "Maintenance-Window"
+  schedule                   = "cron(15 10 ? * MON *)"
+  allow_unassociated_targets = "False"
+  resource_type              = "INSTANCE"
+  owner_information          = "Maintenance Window Task"
+  target_key                 = "InstanceIds"
+  target_values              = ["${module.ar_test.ar_instance_id_list}"]
+}
+
+output "maintenance_window_target_id" {
+  value = "${module.maint_window_target.maintenance_window_target_id}"
+}
+
+output "maintenance_window_id" {
+  value = "${module.maint_window_target.maintenance_window_id}"
+}

--- a/modules/task/main.tf
+++ b/modules/task/main.tf
@@ -1,0 +1,41 @@
+resource "aws_ssm_maintenance_window_task" "maintenance_window_task_with_logging" {
+  count            = "${var.enable_s3_logging ? 1 : 0}"
+  max_errors       = "${var.max_errors}"
+  service_role_arn = "${var.service_role_arn}"
+  priority         = "${var.priority}"
+  task_type        = "${var.task_type}"
+  task_arn         = "${var.task_arn}"
+  window_id        = "${var.window_id}"
+  max_concurrency  = "${var.max_concurrency}"
+
+  task_parameters = ["${var.task_parameters}"]
+
+  targets {
+    key    = "${var.target_key}"
+    values = ["${var.target_values}"]
+  }
+
+  logging_info {
+    s3_bucket_name   = "${var.s3_bucket_name}"
+    s3_region        = "${var.s3_region}"
+    s3_bucket_prefix = "${var.s3_bucket_prefix}"
+  }
+}
+
+resource "aws_ssm_maintenance_window_task" "maintenance_window_task_no_logging" {
+  count            = "${var.enable_s3_logging ? 0 : 1}"
+  max_errors       = "${var.max_errors}"
+  service_role_arn = "${var.service_role_arn}"
+  priority         = "${var.priority}"
+  task_type        = "${var.task_type}"
+  task_arn         = "${var.task_arn}"
+  window_id        = "${var.window_id}"
+  max_concurrency  = "${var.max_concurrency}"
+
+  task_parameters = ["${var.task_parameters}"]
+
+  targets {
+    key    = "${var.target_key}"
+    values = ["${var.target_values}"]
+  }
+}

--- a/modules/task/outputs.tf
+++ b/modules/task/outputs.tf
@@ -1,0 +1,3 @@
+output "maintenance_window_task_id" {
+  value = "${element(coalescelist(aws_ssm_maintenance_window_task.maintenance_window_task_no_logging.*.id, aws_ssm_maintenance_window_task.maintenance_window_task_with_logging.*.id, list("")), 0)}"
+}

--- a/modules/task/variables.tf
+++ b/modules/task/variables.tf
@@ -1,0 +1,82 @@
+variable "enable_s3_logging" {
+  description = "Enable logging to s3 for the maintenance window task. true or false"
+  default     = false
+  type        = "string"
+}
+
+variable "max_concurrency" {
+  description = "The maximum number of targets that you can run this task for, in parallel."
+  default     = 5
+  type        = "string"
+}
+
+variable "max_errors" {
+  description = "The maximum number of errors allowed before this task stops being scheduled. Minimum length of 1. Maximum length of 7"
+  default     = 1
+  type        = "string"
+}
+
+variable "priority" {
+  description = "The priority of the task in the Maintenance Window. The lower the number, the higher the priority. Tasks that have the same priority are scheduled in parallel."
+  default     = 0
+  type        = "string"
+}
+
+variable "service_role_arn" {
+  description = "The ARN of the role that's used when the task is executed."
+  default     = ""
+  type        = "string"
+}
+
+variable "s3_bucket_name" {
+  description = "Logging S3 Bucket Name"
+  default     = ""
+  type        = "string"
+}
+
+variable "s3_bucket_prefix" {
+  description = "Logging S3 Bucket prefix."
+  default     = ""
+  type        = "string"
+}
+
+variable "s3_region" {
+  description = "Logging S3 Bucket region"
+  default     = ""
+  type        = "string"
+}
+
+variable "task_parameters" {
+  description = "The parameters to pass to the task when it's executed."
+  default     = []
+  type        = "list"
+}
+
+variable "target_key" {
+  description = "The Maintenance Window Target ID from the maintenance window target template or InstanceIds"
+  default     = ""
+  type        = "string"
+}
+
+variable "target_values" {
+  description = "Comma delimited list of Physical Maintenance Window Target IDs or Instance IDs."
+  default     = []
+  type        = "list"
+}
+
+variable "task_arn" {
+  description = "The ARN or Document resource that the task uses during execution. https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtask.html#cfn-ssm-maintenancewindowtask-taskarn"
+  type        = "string"
+}
+
+variable "task_type" {
+  description = "The type of task. Only RUN_COMMAND is supported by terraform at this point"
+  default     = "RUN_COMMAND"
+  type        = "string"
+}
+
+variable "window_id" {
+  description = "The ID of the Maintenance Window where the task is registered. Format mw-xxxxxxxxxxxx"
+  default     = ""
+  type        = "string"
+}

--- a/modules/window_and_targets/README.md
+++ b/modules/window_and_targets/README.md
@@ -1,0 +1,35 @@
+## Basic Usage
+```
+module "maint_window_target" {
+  source                     = "git@github.com:rackspace-infrastructure-automation/aws-terraform-maintenance_window//modules/window_and_targets?ref=v0.0.1"
+  cutoff                     = "0"
+  duration                   = "1"
+  name                       = "Maintenance-Window"
+  schedule                   = "cron(15 10 ? * MON *)"
+  allow_unassociated_targets = "False"
+  resource_type              = "INSTANCE"
+  owner_information          = "Maintenance Window Task"
+  target_key                 = "InstanceIds"
+  target_values              = ["${module.ar_test.ar_instance_id_list}"]
+}
+```
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| allow_unassociated_targets | Enables a Maintenance Window task to execute on managed instances, even if you haven't registered those instances as targets. If this is enabled, then you must specify the unregistered instances (by instance ID) when you register a task with the Maintenance Window. | string | `false` | no |
+| cutoff | The number of hours before the end of the Maintenance Window that Systems Manager stops scheduling new tasks for execution. | string | `0` | no |
+| duration | The schedule of the Maintenance Window in the form of a cron or rate expression. | string | `1` | no |
+| name | The name of the Maintenance Window. Must contain only letters, numbers, periods (.), underscores (_), backslashes (\), and dashes (-) | string | `Maintenance-Window` | no |
+| owner_information | A user-provided value to include in any events in CloudWatch Events that are raised while running tasks for these targets in this Maintenance Window. | string | `Maintenance Window Task` | no |
+| resource_type | The type of target that's being registered with the Maintenance Window. | string | `INSTANCE` | no |
+| schedule | The schedule of the Maintenance Window in the form of a cron or rate expression. https://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html | string | - | yes |
+| target_key | The Maintenance Window Target ID from the maintenance window target template or InstanceIds | string | - | yes |
+| target_values | List of Physical Maintenance Window Target IDs or Instance IDs. | list | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| maintenance_window_id | Maintenance Window ID |
+| maintenance_window_target_id | Maintenance Window Target ID |

--- a/modules/window_and_targets/examples/main.tf
+++ b/modules/window_and_targets/examples/main.tf
@@ -1,0 +1,121 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "random_string" "r_string" {
+  length  = 6
+  upper   = true
+  lower   = false
+  special = false
+  number  = false
+}
+
+module "vpc" {
+  source   = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.6"
+  vpc_name = "MAINT-WINDOW-TEST-${random_string.r_string.result}"
+}
+
+data "aws_region" "current_region" {}
+data "aws_caller_identity" "current_account" {}
+
+data "aws_ami" "amazon_centos_7" {
+  most_recent = true
+  owners      = ["679593333241"]
+
+  filter {
+    name   = "name"
+    values = ["CentOS Linux 7 x86_64 HVM EBS*"]
+  }
+}
+
+module "ar_test" {
+  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery.git?ref=v0.0.5"
+  ec2_os              = "centos7"
+  instance_count      = "1"
+  subnets             = ["${element(module.vpc.private_subnets, 0)}"]
+  security_group_list = ["${module.vpc.default_sg}"]
+  image_id            = "${data.aws_ami.amazon_centos_7.image_id}"
+  instance_type       = "t2.micro"
+  resource_name       = "MAINT_WINDOW_TEST-${random_string.r_string.result}"
+}
+
+module "s3_logging" {
+  source            = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.0.3"
+  bucket_name       = "s3logging-${lower(random_string.r_string.result)}"
+  bucket_acl        = "private"
+  bucket_logging    = false
+  environment       = "Development"
+  lifecycle_enabled = false
+  versioning        = false
+}
+
+module "maint_window_target" {
+  source                     = "git@github.com:rackspace-infrastructure-automation/aws-terraform-maintenance_window//modules/window_and_targets?ref=v0.0.1"
+  cutoff                     = "0"
+  duration                   = "1"
+  name                       = "Maintenance-Window"
+  schedule                   = "cron(15 10 ? * MON *)"
+  allow_unassociated_targets = "False"
+  resource_type              = "INSTANCE"
+  owner_information          = "Maintenance Window Task"
+  target_key                 = "InstanceIds"
+  target_values              = ["${module.ar_test.ar_instance_id_list}"]
+}
+
+module "maintenance_window_task_1" {
+  source           = "git@github.com:rackspace-infrastructure-automation/aws-terraform-maintenance_window//modules/task?ref=v0.0.1"
+  max_errors       = "1"
+  service_role_arn = "arn:aws:iam::${data.aws_caller_identity.current_account.account_id}:role/aws-service-role/ssm.amazonaws.com/AWSServiceRoleForAmazonSSM"
+  priority         = "0"
+  task_type        = "RUN_COMMAND"
+  task_arn         = "arn:aws:ssm:${data.aws_region.current_region.name}:507897595701:document/Rack-ConfigureAWSTimeSync"
+  window_id        = "${module.maint_window_target.maintenance_window_id}"
+  max_concurrency  = "5"
+  target_key       = "WindowTargetIds"
+  target_values    = ["${module.maint_window_target.maintenance_window_target_id}"]
+
+  task_parameters = {
+    name   = "PreferredTimeClient"
+    values = ["chrony"]
+  }
+
+  enable_s3_logging = true
+  s3_bucket_name    = "${module.s3_logging.bucket_id}"
+  s3_region         = "${module.s3_logging.bucket_region}"
+}
+
+module "maintenance_window_task_2" {
+  source           = "git@github.com:rackspace-infrastructure-automation/aws-terraform-maintenance_window//modules/task?ref=v0.0.1"
+  max_errors       = "1"
+  service_role_arn = "arn:aws:iam::${data.aws_caller_identity.current_account.account_id}:role/aws-service-role/ssm.amazonaws.com/AWSServiceRoleForAmazonSSM"
+  priority         = "0"
+  task_type        = "RUN_COMMAND"
+  task_arn         = "arn:aws:ssm:${data.aws_region.current_region.name}:507897595701:document/Rack-Install_Package"
+  window_id        = "${module.maint_window_target.maintenance_window_id}"
+  max_concurrency  = "5"
+  target_key       = "WindowTargetIds"
+  target_values    = ["${module.maint_window_target.maintenance_window_target_id}"]
+
+  task_parameters = {
+    name   = "Packages"
+    values = ["bind bind-utils"]
+  }
+
+  enable_s3_logging = false
+}
+
+output "maintenance_window_target_id" {
+  value = "${module.maint_window_target.maintenance_window_target_id}"
+}
+
+output "maintenance_window_id" {
+  value = "${module.maint_window_target.maintenance_window_id}"
+}
+
+output "maintenance_window_task_1_id" {
+  value = "${module.maintenance_window_task_1.maintenance_window_task_id}"
+}
+
+output "maintenance_window_task_2_id" {
+  value = "${module.maintenance_window_task_2.maintenance_window_task_id}"
+}

--- a/modules/window_and_targets/main.tf
+++ b/modules/window_and_targets/main.tf
@@ -1,0 +1,19 @@
+resource "aws_ssm_maintenance_window" "maintenance_window" {
+  cutoff                     = "${var.cutoff}"
+  duration                   = "${var.duration}"
+  name                       = "${var.name}"
+  schedule                   = "${var.schedule}"
+  allow_unassociated_targets = "${var.allow_unassociated_targets}"
+}
+
+resource "aws_ssm_maintenance_window_target" "maintenance_window_target" {
+  resource_type     = "${var.resource_type}"
+  owner_information = "${var.owner_information}"
+
+  targets {
+    key    = "${var.target_key}"
+    values = ["${var.target_values}"]
+  }
+
+  window_id = "${aws_ssm_maintenance_window.maintenance_window.id}"
+}

--- a/modules/window_and_targets/outputs.tf
+++ b/modules/window_and_targets/outputs.tf
@@ -1,0 +1,9 @@
+output "maintenance_window_target_id" {
+  description = "Maintenance Window Target ID"
+  value       = "${aws_ssm_maintenance_window_target.maintenance_window_target.id}"
+}
+
+output "maintenance_window_id" {
+  description = "Maintenance Window ID"
+  value       = "${aws_ssm_maintenance_window.maintenance_window.id}"
+}

--- a/modules/window_and_targets/variables.tf
+++ b/modules/window_and_targets/variables.tf
@@ -1,0 +1,50 @@
+variable "allow_unassociated_targets" {
+  description = "Enables a Maintenance Window task to execute on managed instances, even if you haven't registered those instances as targets. If this is enabled, then you must specify the unregistered instances (by instance ID) when you register a task with the Maintenance Window."
+  default     = false
+  type        = "string"
+}
+
+variable "cutoff" {
+  description = "The number of hours before the end of the Maintenance Window that Systems Manager stops scheduling new tasks for execution."
+  default     = 0
+  type        = "string"
+}
+
+variable "duration" {
+  description = "The schedule of the Maintenance Window in the form of a cron or rate expression."
+  default     = 1
+  type        = "string"
+}
+
+variable "name" {
+  description = "The name of the Maintenance Window. Must contain only letters, numbers, periods (.), underscores (_), backslashes (\\), and dashes (-)"
+  default     = "Maintenance-Window"
+  type        = "string"
+}
+
+variable "owner_information" {
+  description = "A user-provided value to include in any events in CloudWatch Events that are raised while running tasks for these targets in this Maintenance Window."
+  default     = "Maintenance Window Task"
+  type        = "string"
+}
+
+variable "resource_type" {
+  description = "The type of target that's being registered with the Maintenance Window."
+  default     = "INSTANCE"
+  type        = "string"
+}
+
+variable "schedule" {
+  description = "The schedule of the Maintenance Window in the form of a cron or rate expression. https://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html"
+  type        = "string"
+}
+
+variable "target_key" {
+  description = "The Maintenance Window Target ID from the maintenance window target template or InstanceIds"
+  type        = "string"
+}
+
+variable "target_values" {
+  description = "List of Physical Maintenance Window Target IDs or Instance IDs."
+  type        = "list"
+}

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -1,0 +1,122 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "random_string" "r_string" {
+  length  = 6
+  upper   = true
+  lower   = false
+  special = false
+  number  = false
+}
+
+module "vpc" {
+  source   = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.6"
+  vpc_name = "MAINT-WINDOW-TEST-${random_string.r_string.result}"
+}
+
+data "aws_region" "current_region" {}
+data "aws_caller_identity" "current_account" {}
+
+data "aws_ami" "amazon_centos_7" {
+  most_recent = true
+  owners      = ["679593333241"]
+
+  filter {
+    name   = "name"
+    values = ["CentOS Linux 7 x86_64 HVM EBS*"]
+  }
+}
+
+module "ar_test" {
+  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery.git?ref=v0.0.5"
+  ec2_os              = "centos7"
+  instance_count      = "1"
+  subnets             = ["${element(module.vpc.private_subnets, 0)}"]
+  security_group_list = ["${module.vpc.default_sg}"]
+  image_id            = "${data.aws_ami.amazon_centos_7.image_id}"
+  instance_type       = "t2.micro"
+  resource_name       = "MAINT_WINDOW_TEST-${random_string.r_string.result}"
+}
+
+module "s3_logging" {
+  source               = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3?ref=v0.0.4"
+  bucket_name          = "s3logging-${lower(random_string.r_string.result)}"
+  bucket_acl           = "private"
+  bucket_logging       = false
+  environment          = "Development"
+  lifecycle_enabled    = false
+  versioning           = false
+  force_destroy_bucket = true
+}
+
+module "maint_window_target" {
+  source                     = "../../module/modules/window_and_targets"
+  cutoff                     = "0"
+  duration                   = "1"
+  name                       = "Maintenance-Window"
+  schedule                   = "cron(15 10 ? * MON *)"
+  allow_unassociated_targets = "False"
+  resource_type              = "INSTANCE"
+  owner_information          = "Maintenance Window Task"
+  target_key                 = "InstanceIds"
+  target_values              = ["${module.ar_test.ar_instance_id_list}"]
+}
+
+module "maintenance_window_task_1" {
+  source           = "../../module/modules/task"
+  max_errors       = "1"
+  service_role_arn = "arn:aws:iam::${data.aws_caller_identity.current_account.account_id}:role/aws-service-role/ssm.amazonaws.com/AWSServiceRoleForAmazonSSM"
+  priority         = "0"
+  task_type        = "RUN_COMMAND"
+  task_arn         = "arn:aws:ssm:${data.aws_region.current_region.name}:507897595701:document/Rack-ConfigureAWSTimeSync"
+  window_id        = "${module.maint_window_target.maintenance_window_id}"
+  max_concurrency  = "5"
+  target_key       = "WindowTargetIds"
+  target_values    = ["${module.maint_window_target.maintenance_window_target_id}"]
+
+  task_parameters = [{
+    name   = "PreferredTimeClient"
+    values = ["chrony"]
+  }]
+
+  enable_s3_logging = true
+  s3_bucket_name    = "${module.s3_logging.bucket_id}"
+  s3_region         = "${module.s3_logging.bucket_region}"
+}
+
+module "maintenance_window_task_2" {
+  source           = "../../module/modules/task"
+  max_errors       = "1"
+  service_role_arn = "arn:aws:iam::${data.aws_caller_identity.current_account.account_id}:role/aws-service-role/ssm.amazonaws.com/AWSServiceRoleForAmazonSSM"
+  priority         = "0"
+  task_type        = "RUN_COMMAND"
+  task_arn         = "arn:aws:ssm:${data.aws_region.current_region.name}:507897595701:document/Rack-Install_Package"
+  window_id        = "${module.maint_window_target.maintenance_window_id}"
+  max_concurrency  = "5"
+  target_key       = "WindowTargetIds"
+  target_values    = ["${module.maint_window_target.maintenance_window_target_id}"]
+
+  task_parameters = [{
+    name   = "Packages"
+    values = ["bind bind-utils"]
+  }]
+
+  enable_s3_logging = false
+}
+
+output "maintenance_window_target_id" {
+  value = "${module.maint_window_target.maintenance_window_target_id}"
+}
+
+output "maintenance_window_id" {
+  value = "${module.maint_window_target.maintenance_window_id}"
+}
+
+output "maintenance_window_task_1_id" {
+  value = "${module.maintenance_window_task_1.maintenance_window_task_id}"
+}
+
+output "maintenance_window_task_2_id" {
+  value = "${module.maintenance_window_task_2.maintenance_window_task_id}"
+}


### PR DESCRIPTION
- Submodules to create maintenance window, maintenance window targets, maintenance window tasks
- Only `RUN_COMMAND` is currently supported by Terraform on maintenance window task.
- Separate submodules were created instead of a single module for the purpose of allowing the user to assign multiple tasks to a single maintenance window and target set.